### PR TITLE
Convert from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,52 +2,27 @@ name: CI
 
 on:
   push:
-    branches: [ master, main ]
-  pull_request:
-    branches: [ master, main ]
   workflow_dispatch:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        destination:
-          - platform=macOS,arch=x86_64
-          - platform=iOS Simulator,name=iPhone 15,OS=latest
-    
     runs-on: macos-latest
     
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       
+    - name: Select Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
+      
     - name: Show Xcode version
       run: xcodebuild -version
-      
-    - name: List available schemes
-      run: xcodebuild -list
       
     - name: Run tests
       run: |
         xcodebuild \
           -scheme "hsluv-objc" \
-          -destination "${{ matrix.destination }}" \
+          -destination "platform=macOS,arch=x86_64" \
           -enableCodeCoverage YES \
-          -derivedDataPath DerivedData \
           CODE_SIGNING_REQUIRED=NO \
-          test
-          
-    - name: Generate test report
-      if: always()
-      run: |
-        xcrun xccov view --report --json DerivedData/Logs/Test/*.xcresult > coverage.json || true
-        
-    - name: Upload test results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results-${{ strategy.job-index }}
-        path: |
-          DerivedData/Logs/Test/
-          coverage.json
-        retention-days: 30 
+          test 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master, main ]
-  pull_request:
-    branches: [ master, main ]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Select Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
+      
+    - name: Show Xcode version
+      run: xcodebuild -version
+      
+    - name: Run tests
+      run: |
+        xcodebuild \
+          -scheme "hsluv-objc" \
+          -destination "platform=macOS,arch=x86_64" \
+          -enableCodeCoverage YES \
+          CODE_SIGNING_REQUIRED=NO \
+          test 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,27 +2,52 @@ name: CI
 
 on:
   push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
   workflow_dispatch:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        destination:
+          - platform=macOS,arch=x86_64
+          - platform=iOS Simulator,name=iPhone 15,OS=latest
+    
     runs-on: macos-latest
     
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       
-    - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
-      
     - name: Show Xcode version
       run: xcodebuild -version
+      
+    - name: List available schemes
+      run: xcodebuild -list
       
     - name: Run tests
       run: |
         xcodebuild \
           -scheme "hsluv-objc" \
-          -destination "platform=macOS,arch=x86_64" \
+          -destination "${{ matrix.destination }}" \
           -enableCodeCoverage YES \
+          -derivedDataPath DerivedData \
           CODE_SIGNING_REQUIRED=NO \
-          test 
+          test
+          
+    - name: Generate test report
+      if: always()
+      run: |
+        xcrun xccov view --report --json DerivedData/Logs/Test/*.xcresult > coverage.json || true
+        
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results-${{ strategy.job-index }}
+        path: |
+          DerivedData/Logs/Test/
+          coverage.json
+        retention-days: 30 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: objective-c
-osx_image: xcode8.2
-script:
-  - xcodebuild -scheme "hsluv-objc" -destination "arch=x86_64" CODE_SIGNING_REQUIRED=NO test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Cocoapod compatible](https://img.shields.io/cocoapods/v/hsluv-objc.svg)](https://cocoapods.org/pods/hsluv-objc)
-[![Build Status](https://travis-ci.org/hsluv/hsluv-objc.svg?branch=master)](https://travis-ci.org/hsluv/hsluv-objc)
+[![CI](https://github.com/hsluv/hsluv-objc/actions/workflows/ci.yml/badge.svg)](https://github.com/hsluv/hsluv-objc/actions/workflows/ci.yml)
 
 #hsluv-objc
 


### PR DESCRIPTION
This PR converts the project from Travis CI to GitHub Actions. Removed deprecated .travis.yml and added modern .github/workflows/ci.yml with macos-latest runner, code coverage, and manual dispatch trigger.